### PR TITLE
修改bug

### DIFF
--- a/Service/StaRepo/src/main/java/com/hzgc/service/starepo/service/ObjectInfoHandlerService.java
+++ b/Service/StaRepo/src/main/java/com/hzgc/service/starepo/service/ObjectInfoHandlerService.java
@@ -550,7 +550,7 @@ public class ObjectInfoHandlerService {
                 // 布控时间
                 map.put("time", "时间");
                 if (null != personObject.getCreateTime()) {
-                    map.put("timeData", new SimpleDateFormat("yyyy-MM-dd hh:mm:ss").format(personObject.getCreateTime()));
+                    map.put("timeData", personObject.getCreateTime());
                 } else {
                     map.put("timeData", "");
                 }


### PR DESCRIPTION
静态库搜索历史记录，现在保存的时间是格式化之后的String，所以在导出文件时时间字段不需要再次转换，否者会报错。